### PR TITLE
Address python2 / python3 unicode issue

### DIFF
--- a/river/models/proceeding_meta.py
+++ b/river/models/proceeding_meta.py
@@ -1,5 +1,8 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.db.models.signals import m2m_changed, post_save
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from river.config import app_config
@@ -10,6 +13,7 @@ from river.models.transition import Transition
 __author__ = 'ahmetdal'
 
 
+@python_2_unicode_compatible
 class ProceedingMeta(BaseModel):
     class Meta:
         app_label = 'river'
@@ -34,7 +38,7 @@ class ProceedingMeta(BaseModel):
     def natural_key(self):
         return self.content_type, self.field, self.transition, self.order
 
-    def __unicode__(self):
+    def __str__(self):
         return 'Transition:%s, Permissions:%s, Groups:%s, Order:%s' % (
             self.transition, ','.join(self.permissions.values_list('name', flat=True)),
             ','.join(self.groups.values_list('name', flat=True)), self.order)

--- a/river/models/state.py
+++ b/river/models/state.py
@@ -1,6 +1,9 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.db.models.signals import pre_save
 from django.template.defaultfilters import slugify
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from river.models.base_model import BaseModel
@@ -9,6 +12,7 @@ from river.models.managers.state import StateManager
 __author__ = 'ahmetdal'
 
 
+@python_2_unicode_compatible
 class State(BaseModel):
     class Meta:
         app_label = 'river'
@@ -21,7 +25,7 @@ class State(BaseModel):
     label = models.CharField(max_length=50)
     description = models.CharField(_("Description"), max_length=200, null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
     def natural_key(self):

--- a/river/models/transition.py
+++ b/river/models/transition.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
+
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from river.models.base_model import BaseModel
@@ -16,6 +19,7 @@ DIRECTIONS = [
 ]
 
 
+@python_2_unicode_compatible
 class Transition(BaseModel):
     class Meta:
         app_label = 'river'
@@ -33,5 +37,5 @@ class Transition(BaseModel):
     def natural_key(self):
         return self.source_state.slug, self.destination_state.slug
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s -> %s' % (self.source_state, self.destination_state)

--- a/river/services/transition.py
+++ b/river/services/transition.py
@@ -61,8 +61,8 @@ class TransitionService(object):
                         available_states = StateService.get_available_states(workflow_object, field, user)
                         raise RiverException(ErrorCode.INVALID_NEXT_STATE_FOR_USER,
                                              "Invalid state is given(%s). Valid states is(are) %s" % (
-                                                 next_state.__unicode__(),
-                                                 ','.join([ast.__unicode__() for ast in available_states])))
+                                                 next_state.__str__(),
+                                                 ','.join([ast.__str__() for ast in available_states])))
                 else:
                     raise RiverException(ErrorCode.NEXT_STATE_IS_REQUIRED,
                                          "State must be given when there are multiple states for destination")

--- a/river/tests/services/test__transition_service.py
+++ b/river/tests/services/test__transition_service.py
@@ -231,7 +231,7 @@ class test__TransitionService(BaseTestCase):
         except RiverException as e:
             self.assertEqual(str(e),
                              "Invalid state is given(%s). Valid states is(are) %s" % (
-                                 State.objects.get(label='s3').__unicode__(), ','.join([ast.__unicode__() for ast in State.objects.filter(label__in=['s4', 's5'])])))
+                                 State.objects.get(label='s3').__str__(), ','.join([ast.__str__() for ast in State.objects.filter(label__in=['s4', 's5'])])))
             self.assertEqual(ErrorCode.INVALID_NEXT_STATE_FOR_USER, e.code)
 
 


### PR DESCRIPTION
@javrasya  Python 3 should be returning `_str_ (python3)` so in order to support Python 2 and Python 3 i added these changes according to https://docs.djangoproject.com/en/1.10/topics/python3/#str-and-unicode-methods.