### PR TITLE
Proceeding Service - Allow the permissions logic to be overridden

### DIFF
--- a/river/config.py
+++ b/river/config.py
@@ -20,6 +20,7 @@ class RiverConfig(object):
         self.PERMISSION_CLASS = getattr(settings, self.get_with_prefix('PERMISSION_CLASS'), Permission)
         self.GROUP_CLASS = getattr(settings, self.get_with_prefix('GROUP_CLASS'), Group)
         self.HANDLER_BACKEND = getattr(settings, self.get_with_prefix('HANDLER_BACKEND'), {'backend': 'river.handlers.backends.memory.MemoryHandlerBackend'})
+        self.PROCEEDING_SERVICE = getattr(settings, self.get_with_prefix('PROCEEDING_SERVICE'), 'river.services.proceeding.ProceedingService')
 
         # Generated
         self.HANDLER_BACKEND_CLASS = self.HANDLER_BACKEND.get('backend')

--- a/river/models/fields/state.py
+++ b/river/models/fields/state.py
@@ -1,3 +1,4 @@
+from pydoc import locate
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import CASCADE
 from django.db.models.signals import post_save
@@ -14,6 +15,7 @@ from river.models.state import State
 from river.models.proceeding import Proceeding
 from river.services.object import ObjectService
 from river.services.transition import TransitionService
+from river.config import app_config
 
 __author__ = 'ahmetdal'
 
@@ -63,25 +65,25 @@ class StateField(models.ForeignKey):
             return StateService.get_initial_state(ContentType.objects.get_for_model(self))
 
         def get_available_proceedings(self, *args, **kwargs):
-            from river.services.proceeding import ProceedingService
+            ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
             return ProceedingService.get_available_proceedings(self, [self.get_state()], *args, **kwargs)
 
         @property
         def initial_proceedings(self):
-            from river.services.proceeding import ProceedingService
+            ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
             return self.get_state() in ProceedingService.get_initial_proceedings(ContentType.objects.get_for_model(self))
 
         @property
         def final_proceedings(self):
-            from river.services.proceeding import ProceedingService
+            ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
             return self.get_state() in ProceedingService.get_final_proceedings(ContentType.objects.get_for_model(self))
 
         @property
         def next_proceedings(self):
-            from river.services.proceeding import ProceedingService
+            ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
             return self.get_state() in ProceedingService.get_next_proceedings(ContentType.objects.get_for_model(self))
 

--- a/river/models/proceeding_meta.py
+++ b/river/models/proceeding_meta.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from pydoc import locate
 
 from django.db import models
 from django.db.models import CASCADE
@@ -44,7 +45,7 @@ class ProceedingMeta(BaseModel):
 
 
 def post_group_change(sender, instance, *args, **kwargs):
-    from river.services.proceeding import ProceedingService
+    ProceedingService = locate(app_config.PROCEEDING_SERVICE)
     from river.models.proceeding import PENDING
 
     for proceeding_pending in instance.proceedings.filter(status=PENDING):
@@ -53,7 +54,7 @@ def post_group_change(sender, instance, *args, **kwargs):
 
 def post_permissions_change(sender, instance, *args, **kwargs):
     from river.models.proceeding import PENDING
-    from river.services.proceeding import ProceedingService
+    ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
     for proceeding_pending in instance.proceedings.filter(status=PENDING):
         ProceedingService.override_permissions(proceeding_pending, instance.permissions.all())

--- a/river/services/object.py
+++ b/river/services/object.py
@@ -1,7 +1,10 @@
+from pydoc import locate
+from river.config import app_config
 from river.models.proceeding import Proceeding
-from river.services.proceeding import ProceedingService
 from river.utils.error_code import ErrorCode
 from river.utils.exceptions import RiverException
+
+ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
 __author__ = 'ahmetdal'
 

--- a/river/services/proceeding.py
+++ b/river/services/proceeding.py
@@ -39,7 +39,9 @@ class ProceedingService(object):
     def get_user_permissions(workflow_object, source_states, **kwargs):
         """
         Override this method to customize how river determines a user's
-        permissions
+        permissions. This method must return an array of strings that match
+        the following format:
+        ['app_label.codename', 'app_label.codename', ...]
         """
         user = kwargs.get('user')
         permissions = []

--- a/river/services/state.py
+++ b/river/services/state.py
@@ -1,8 +1,11 @@
+from pydoc import locate
+from river.config import app_config
 from river.models.proceeding import Proceeding
 from river.models.state import State
 from river.utils.error_code import ErrorCode
 from river.utils.exceptions import RiverException
-from .proceeding import ProceedingService
+
+ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
 __author__ = 'ahmetdal'
 

--- a/river/services/transition.py
+++ b/river/services/transition.py
@@ -1,16 +1,19 @@
 import logging
 from datetime import datetime
+from pydoc import locate
 
 from django.db.transaction import atomic
 
+from river.config import app_config
 from river.models.proceeding import APPROVED
-from river.services.proceeding import ProceedingService
 from river.services.state import StateService
 from river.signals import ProceedingSignal, TransitionSignal, FinalSignal
 from river.utils.error_code import ErrorCode
 from river.utils.exceptions import RiverException
 
 __author__ = 'ahmetdal'
+
+ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 
 
 class TTSSignal(object):

--- a/river/tests/services/test__proceeding_service.py
+++ b/river/tests/services/test__proceeding_service.py
@@ -1,19 +1,21 @@
+from pydoc import locate
 from datetime import datetime, timedelta
 
 from django.contrib.auth.models import Group
 from django.core.management import call_command
 
+from river.config import app_config
 from river.models.factories import UserObjectFactory
 from river.models.proceeding import Proceeding
 from river.models.proceeding_meta import ProceedingMeta
 from river.models.state import State
 from river.services.object import ObjectService
-from river.services.proceeding import ProceedingService
 from river.tests.base_test import BaseTestCase
 from river.tests.models import TestModelSlowCase1
 from river.tests.models import TestModelSlowCase2
 from river.tests.models.factories import TestModelObjectFactory
 
+ProceedingService = locate(app_config.PROCEEDING_SERVICE)
 __author__ = 'ahmetdal'
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -86,7 +86,3 @@ LOGGING = {
     }
 }
 
-AUTHENTICATION_BACKENDS = (
-    'django_cas.backends.CASBackend',
-    'django.contrib.auth.backends.ModelBackend',
-)

--- a/test_settings.py
+++ b/test_settings.py
@@ -85,3 +85,8 @@ LOGGING = {
         }
     }
 }
+
+AUTHENTICATION_BACKENDS = (
+    'django_cas.backends.CASBackend',
+    'django.contrib.auth.backends.ModelBackend',
+)


### PR DESCRIPTION
This project looks like it has a lot of powerful functionality and potential! However, I have a use case that does not fit the current package. I need to override the way the `ProceedingService` class gathers Permissions data for the user. Rather than looking at the `Permission` models to determine if the user can execute a transition, I want to be able to incorporate `django-guardian`'s Object-level permissions into my `ProceedingMeta`s.

This PR changes `ProceedingService` so it is dynamically loaded, rather than using a hard-coded import. This allows a developer to subclass the built-in `ProceedingService` class and override the `get_user_permission` method which I introduced. The developer could use whatever Permissions backend they choose, whether it be `django-guardian` or some other Django package. The key is that an array of permission codenames is returned. This format is described in the docstring of the `get_user_permission` method.

I see all tests are passing with these changes. Let me know if there are additional changes that should be made for this functionality to make it into the package.

Thanks for considering this PR.