### PR TITLE
[#74] Log all the workflow fields that doesn't have a workflow meta correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,24 +107,6 @@ Usage
     Make sure that there is only one initial state defined in your workflow, so that ``django-river`` can pick that one automatically
     when a model object is created. All other workflow items will be managed by ``django-river`` after object creations.
 
-
-
-Example Scenarios
------------------
-Simple Issue Tracking System
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Re-Open case
-""""""""""""
-|Re Open Case|
-
-Closed without Re-Open case
-"""""""""""""""""""""""""""
-|Closed Without Re Open Case|
-
-Closed with Re-Open case
-""""""""""""""""""""""""
-|Closed With Re Open Case|
-
 Contribute
 ----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,8 +3,15 @@
 Change Logs
 ===========
 
-1.0.0 (Development)
-------------------
+1.0.1 (Stable)
+--------------
+    * **Bug** - # 74_ : Fields that have no transition approval meta are now logged correctly.
+    * **Bug** - ``django`` version is now fixed to 2.1 for coverage in the build to make the build pass
+
+.. _74: https://github.com/javrasya/django-river/issues/74
+
+1.0.0
+-----
 ``django-river`` is finally having it's first major version bump. In this version, all code and the APIs are revisited
 and are much easier to understand how it works and much easier to use it now. In some places even more performant. 
 There are also more documentation with this version. Stay tuned :-)
@@ -21,8 +28,8 @@ There are also more documentation with this version. Stay tuned :-)
     * **Improvement** - Minor improvements on admin pages
     * **Improvement** - Some performance improvements
 
-0.10.0 (Stable)
---------------
+0.10.0
+------
 
     * # 39_ - **Improvement** -  Django has dropped support for pypy-3. So, It should be dropped from django itself too.
     * **Remove** -  ``pypy`` support has been dropped
@@ -32,7 +39,7 @@ There are also more documentation with this version. Stay tuned :-)
 .. _39: https://github.com/javrasya/django-river/issues/39
 
 0.9.0
--------------
+-----
 
     * # 30_ - **Bug** -  Missing migration file which is ``0007`` because of ``Python2.7`` can not detect it.
     * # 31_ - **Improvement** - unicode issue for Python3.

--- a/river/apps.py
+++ b/river/apps.py
@@ -38,4 +38,4 @@ class RiverApp(AppConfig):
     @classmethod
     def _get_all_workflow_fields(cls):
         from river.core.workflowregistry import workflow_registry
-        return reduce(operator.concat, map(lambda s: list(s), workflow_registry.workflows.values()))
+        return reduce(operator.concat, map(list, workflow_registry.workflows.values()))

--- a/river/apps.py
+++ b/river/apps.py
@@ -1,4 +1,6 @@
 import logging
+import operator
+from functools import reduce
 
 from django.apps import AppConfig
 from django.db.utils import OperationalError, ProgrammingError
@@ -16,9 +18,8 @@ class RiverApp(AppConfig):
 
         from river.hooking.backends.database import DatabaseHookingBackend
         from river.hooking.backends.loader import callback_backend
-        from river.core.workflowregistry import workflow_registry
 
-        for field_name in workflow_registry.workflows:
+        for field_name in self._get_all_workflow_fields():
             try:
                 transition_approval_meta = self.get_model('TransitionApprovalMeta').objects.filter(field_name=field_name)
                 if transition_approval_meta.count() == 0:
@@ -33,3 +34,8 @@ class RiverApp(AppConfig):
             except (OperationalError, ProgrammingError):
                 pass
         LOGGER.debug('RiverApp is loaded.')
+
+    @classmethod
+    def _get_all_workflow_fields(cls):
+        from river.core.workflowregistry import workflow_registry
+        return reduce(operator.concat, map(lambda s: list(s), workflow_registry.workflows.values()))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except IOError as err:
 
 setup(
     name='django-river',
-    version='1.0.0',
+    version='1.0.1',
     author='Ahmet DAL',
     author_email='ceahmetdal@gmail.com',
     packages=find_packages(),

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ basepython = python3.6
 deps =
     pytest-django
     pytest-cov
-    django
+    django>=2.1,<2.2.0
     -rrequirements.txt
 commands =
     py.test --ds='test_settings' --cov ./ --cov-report term-missing


### PR DESCRIPTION
The application doesn't log the fields that have no transition approval meta properly. It logs the mode class id instead. ( Referring to #74 )