### PR TITLE
get_all_permissions is not available on all Authentication Backends

### DIFF
--- a/river/driver/orm_driver.py
+++ b/river/driver/orm_driver.py
@@ -48,7 +48,8 @@ class OrmDriver(RiverDriver):
 
         permissions = []
         for backend in auth.get_backends():
-            permissions.extend(backend.get_all_permissions(as_user))
+            if hasattr(backend, "get_all_permissions"):
+                permissions.extend(backend.get_all_permissions(as_user))
 
         permission_q = Q()
         for p in permissions:


### PR DESCRIPTION
For example, GraphQL JWT does not have get_all_permissions. Thus, there should be a check to identify whether the definition is supported or not.