### PR TITLE
Update function.rst

### DIFF
--- a/docs/hooking/function.rst
+++ b/docs/hooking/function.rst
@@ -114,8 +114,8 @@ Example Function
         def _handle_my_transitions(hook):
             workflow = hook['payload']['workflow']
             workflow_object = hook['payload']['workflow_object']
-            source_state = hook['payload']['transition_approval'].meta.source_state
-            destination_state = hook['payload']['transition_approval'].meta.destination_state
+            source_state = hook['payload']['transition_approval'].meta.transition_meta.source_state
+            destination_state = hook['payload']['transition_approval'].meta.transition_meta.destination_state
             last_approved_by = hook['payload']['transition_approval'].transactioner
             if hook['when'] == BEFORE:
                 print('A transition from %s to %s will soon happen on the object with id:%s and field_name:%s!' % (source_state.label, destination_state.label, workflow_object.pk, workflow.field_name))


### PR DESCRIPTION
When I test the hook function [example function](https://django-river.readthedocs.io/en/latest/hooking/function.html#example-function) in django-river-v3.2.0, it will raise following execption:

```
'TransitionApprovalMeta' object has no attribute 'source_state'
Traceback (most recent call last):
  ...
    self.callback_function.get()(context)
  File "<string>", line 46, in _wrapper
  File "<string>", line 39, in handle
  File "<string>", line 10, in _handle_my_transitions
AttributeError: 'TransitionApprovalMeta' object has no attribute 'source_state'
```

I think maybe some api have changed and document have not updated in time. Please check it, thank you.