### PR TITLE
🔥 Drop support for Django 1.11, 2.0, 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,28 +3,26 @@ sudo: false
 cache: pip
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27-dj1.11-sqlite3
-    - python: "3.5"
-      env: TOXENV=py35-dj1.11-sqlite3
-    - python: "3.5"
-      env: TOXENV=py35-dj2.0-sqlite3
-    - python: "3.5"
-      env: TOXENV=py35-dj2.1-sqlite3
     - python: "3.5"
       env: TOXENV=py35-dj2.2-sqlite3
-    - python: "3.6"
-      env: TOXENV=py36-dj1.11-sqlite3
-    - python: "3.6"
-      env: TOXENV=py36-dj2.0-sqlite3
-    - python: "3.6"
-      env: TOXENV=py36-dj2.1-sqlite3
     - python: "3.6"
       env: TOXENV=py36-dj2.2-sqlite3
     - python: "3.6"
       env: TOXENV=py36-dj3.0-sqlite3
     - python: "3.6"
       env: TOXENV=py36-dj3.1-sqlite3
+    - python: "3.7"
+      env: TOXENV=py37-dj2.2-sqlite3
+    - python: "3.7"
+      env: TOXENV=py37-dj3.0-sqlite3
+    - python: "3.7"
+      env: TOXENV=py37-dj3.1-sqlite3
+    - python: "3.8"
+      env: TOXENV=py38-dj2.2-sqlite3
+    - python: "3.8"
+      env: TOXENV=py38-dj3.0-sqlite3
+    - python: "3.8"
+      env: TOXENV=py38-dj3.1-sqlite3
     - python: "3.6"
       env: TOXENV=cov
     - python: "3.6"

--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,10 @@ A very modern admin with some user friendly interfaces that is called `River Adm
 
 Requirements
 ------------
-* Python (``2.7``, ``3.5``, ``3.6``)
-* Django (``1.11``, ``2.0``, ``2.1``, ``2.2``, ``3.0``, ``3.1``)
-* ``Django`` >= 2.0 is supported for ``Python`` >= 3.5
+* Python (``3.5`` (for Django ``2.2`` only), ``3.6``, ``3.7``, ``3.8``)
+* Django (``2.2``, ``3.0``, ``3.1``)
+* ``Django`` = 2.2 is supported for ``Python`` >= 3.5
+* ``Django`` >= 3.0 is supported for ``Python`` >= 3.6
 
 Supported (Tested) Databases:
 -----------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = {py27}-{dj1.11}-{sqlite3},
-          {py35}-{dj1.11,dj2.0,dj2.1,dj2.2}-{sqlite3},
-          {py36}-{dj1.11,dj2.0,dj2.1,dj2.2,dj3.0}-{sqlite3},
-          {py36}-{dj1.11,dj2.0,dj2.1,dj2.2,dj3.1}-{sqlite3},
+envlist = {py35}-{dj2.2}-{sqlite3},
+          {py36}-{dj2.2,dj3.0,dj3.1}-{sqlite3},
+          {py37}-{dj2.2,dj3.0,dj3.1}-{sqlite3},
+          {py38}-{dj2.2,dj3.0,dj3.1}-{sqlite3},
+          {py39}-{dj2.2,dj3.0,dj3.1}-{sqlite3},
           {py36}-{dj2.2}-{postgresql9,postgresql10,postgresql11,postgresql12},
           {py36}-{dj2.2}-{mysql8.0},
           {py36}-{dj2.2}-{msqsql17,mssql19},
@@ -37,9 +38,6 @@ deps =
     pytest-django>3.1.2
     pytest-cov
     -rrequirements.txt
-    dj1.11: Django>=1.11,<1.12.0
-    dj2.0: Django>=2.0,<2.1.0
-    dj2.1: Django>=2.1,<2.2.0
     dj2.2: Django>=2.2,<2.3.0
     dj3.0: Django>=3.0,<3.1.0
     dj3.1: Django>=3.1,<3.2.0


### PR DESCRIPTION
Also bumped up the python support to include python 3.7, 3.8 and 3.9

closed #181
closed #182
closed #179