### PR TITLE
Fix cyclic graph state explosion

### DIFF
--- a/river/core/classworkflowobject.py
+++ b/river/core/classworkflowobject.py
@@ -3,6 +3,12 @@ from django.contrib.contenttypes.models import ContentType
 from river.driver.mssql_driver import MsSqlDriver
 from river.driver.orm_driver import OrmDriver
 from river.models import State, TransitionApprovalMeta, Workflow, app_config, TransitionMeta
+from functools import lru_cache
+
+
+@lru_cache(None)
+def get_cached_workflow(field_name, content_type):
+    return Workflow.objects.filter(field_name=field_name, content_type=content_type).first()
 
 
 class ClassWorkflowObject(object):
@@ -10,7 +16,7 @@ class ClassWorkflowObject(object):
     def __init__(self, wokflow_object_class, field_name):
         self.wokflow_object_class = wokflow_object_class
         self.field_name = field_name
-        self.workflow = Workflow.objects.filter(field_name=self.field_name, content_type=self._content_type).first()
+        self.workflow = get_cached_workflow(field_name=self.field_name, content_type=self._content_type)
         self._cached_river_driver = None
 
     @property

--- a/river/core/instanceworkflowobject.py
+++ b/river/core/instanceworkflowobject.py
@@ -135,12 +135,16 @@ class InstanceWorkflowObject(object):
             self.set_state(approval.transition.destination_state)
             has_transit = True
 
+        LOGGER.debug("Workflow object %s is proceeded for next transition. Transition: %s -> %s" % (   
+                self.workflow_object, previous_state, self.get_state()))
+
         if next_state:
             self.initialize_approvals(approval.transition.iteration + 1)
         
         with self._approve_signal(approval), self._transition_signal(has_transit, approval), self._on_complete_signal():
             self.workflow_object.save()
-    
+
+
     @atomic
     def cancel_impossible_future(self, approved_approval):
         transition = approved_approval.transition

--- a/river/models/fields/state.py
+++ b/river/models/fields/state.py
@@ -70,7 +70,7 @@ class StateField(models.ForeignKey):
 
 def _on_workflow_object_saved(sender, instance, created, *args, **kwargs):
     for instance_workflow in instance.river.all(instance.__class__):
-        if created:
+        if created and instance_workflow.workflow:
             instance_workflow.initialize_approvals()
             if not instance_workflow.get_state():
                 init_state = getattr(instance.__class__.river, instance_workflow.field_name).initial_state

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except IOError as err:
 
 setup(
     name='django-river',
-    version='3.3.0',
+    version='3.3.1',
     author='Ahmet DAL',
     author_email='ceahmetdal@gmail.com',
     packages=find_packages(),


### PR DESCRIPTION
When states cycle A->B->A->B, there are a truly exponential number of states that get created. Two such cycles are enough to cause 10s + loading times for pages, and realistically will easily break altogether.

Big thank you to @JohnieBraaf for the fixes here. 

This should fix https://github.com/javrasya/django-river/issues/188
and https://github.com/javrasya/django-river/issues/120

The problem is discussed in detail in the above issues.