### PR TITLE
Add six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
         "Django",
         "django-mptt==0.9.1",
         "django-cte==1.1.4",
-        "django-codemirror2==0.2"
+        "django-codemirror2==0.2",
+        "six==1.16.0",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
when you use `git clone` and then run `pip install -r requirements.txt`, six is available as a dependency of one of the packages, but when you do a `pip install django-river` (or in my case `pipenv install django-river`) and include `river` in the `INSTALLED_APPS`; upon running the server you'll see an error related to `six` not being available.

This PR fixes that.