### PR TITLE
Upgrade to Django v4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django-mptt==0.9.1
+django-mptt==0.14.0
 factory-boy==2.11.1
 mock==2.0.0
 pyhamcrest==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ django-mptt==0.14.0
 factory-boy==2.11.1
 mock==2.0.0
 pyhamcrest==1.9.0
-django-cte==1.1.4
+django-cte==1.2.1
 django-codemirror2==0.2
 behave-django==1.3.0

--- a/river/models/base_model.py
+++ b/river/models/base_model.py
@@ -1,7 +1,10 @@
 from django.conf import settings
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models.managers.rivermanager import RiverManager
 

--- a/river/models/function.py
+++ b/river/models/function.py
@@ -3,7 +3,10 @@ import re
 
 from django.db import models
 from django.db.models.signals import pre_save
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models import BaseModel
 

--- a/river/models/hook.py
+++ b/river/models/hook.py
@@ -3,7 +3,10 @@ import logging
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import PROTECT
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models import Workflow, GenericForeignKey, BaseModel
 from river.models.function import Function

--- a/river/models/on_approved_hook.py
+++ b/river/models/on_approved_hook.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.db.models import CASCADE
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models import TransitionApprovalMeta, TransitionApproval
 from river.models.hook import Hook

--- a/river/models/on_transit_hook.py
+++ b/river/models/on_transit_hook.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.db.models import CASCADE
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models import TransitionMeta, Transition
 from river.models.hook import Hook

--- a/river/models/state.py
+++ b/river/models/state.py
@@ -9,7 +9,10 @@ try:
 except ImportError:
     from six import python_2_unicode_compatible
 
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models.base_model import BaseModel
 from river.models.managers.state import StateManager

--- a/river/models/transition.py
+++ b/river/models/transition.py
@@ -10,7 +10,10 @@ except ImportError:
     from django.contrib.contenttypes.generic import GenericForeignKey
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models.base_model import BaseModel
 from river.models.managers.transitionapproval import TransitionApprovalManager

--- a/river/models/transitionapproval.py
+++ b/river/models/transitionapproval.py
@@ -12,7 +12,10 @@ except ImportError:
     from django.contrib.contenttypes.generic import GenericForeignKey
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models.base_model import BaseModel
 from river.models.managers.transitionapproval import TransitionApprovalManager

--- a/river/models/transitionapprovalmeta.py
+++ b/river/models/transitionapprovalmeta.py
@@ -3,8 +3,10 @@ from __future__ import unicode_literals
 from django.db import models, transaction
 from django.db.models import PROTECT
 from django.db.models.signals import post_save, pre_delete
-from django.utils.translation import ugettext_lazy as _
-
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 from river.config import app_config
 from river.models import Workflow
 from river.models.base_model import BaseModel

--- a/river/models/transitionmeta.py
+++ b/river/models/transitionmeta.py
@@ -2,7 +2,10 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.db.models import PROTECT
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.models import State, Workflow
 from river.models.base_model import BaseModel

--- a/river/models/workflow.py
+++ b/river/models/workflow.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.db.models import PROTECT
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 from river.config import app_config
 from river.models import BaseModel, State

--- a/river/signals.py
+++ b/river/signals.py
@@ -10,14 +10,14 @@ from river.models.on_approved_hook import OnApprovedHook
 from river.models.on_complete_hook import OnCompleteHook
 from river.models.on_transit_hook import OnTransitHook
 
-pre_on_complete = Signal(providing_args=["workflow_object", "field_name", ])
-post_on_complete = Signal(providing_args=["workflow_object", "field_name", ])
+pre_on_complete = Signal()
+post_on_complete = Signal()
 
-pre_transition = Signal(providing_args=["workflow_object", "field_name", "source_state", "destination_state"])
-post_transition = Signal(providing_args=["workflow_object", "field_name", "source_state", "destination_state"])
+pre_transition = Signal()
+post_transition = Signal()
 
-pre_approve = Signal(providing_args=["workflow_object", "field_name", "transition_approval"])
-post_approve = Signal(providing_args=["workflow_object", "field_name", "transition_approval", "transition_approval_meta"])
+pre_approve = Signal()
+post_approve = Signal()
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
I tried to test django-river on new versions of Django(v4). There were some errors. Tried to fix it with this PR.

- `ugettext_lazy` was deprecated in v2.2 and no longer used in django v3+. [Reference](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#lazy-translations).
- Upgrade `django-mptt` package from 0.9.1 to 0.14. [Reference](https://bobbyhadz.com/blog/python-importerror-cannot-import-name-smart-text-from-django-utils-encoding)
- Remove `providing_args` argument from `django.dispatch.dispatcher.Signal`objects. [Reference](https://stackoverflow.com/questions/70466886/typeerror-init-got-an-unexpected-keyword-argument-providing-args).